### PR TITLE
Typo in doc

### DIFF
--- a/docs/en/index.md
+++ b/docs/en/index.md
@@ -460,7 +460,7 @@ Then this code should go in our presenter:
 ```php
 public function indexAction($name)
 {
-	$client = $this->bunny->getRpcClient('integerStore');
+	$client = $this->bunny->getRpcClient('parallel');
 
 	$client->addRequest($name, 'charCount', 'charCount');
 	$client->addRequest(serialize(array('min' => 0, 'max' => 10)), 'randomInt', 'randomInt');


### PR DESCRIPTION
Related to [parallel RPC](https://github.com/mishak87/RabbitMq/blob/fed21218dc2d480adfbb078f83fc189306a6e4ec/docs/en/index.md#parallel-rpc) which is not so apparent from diff.
