### PR TITLE
Fixed ConsumerCommand not handling signals when idle

### DIFF
--- a/src/Kdyby/RabbitMq/Consumer.php
+++ b/src/Kdyby/RabbitMq/Consumer.php
@@ -15,6 +15,7 @@ use PhpAmqpLib\Message\AMQPMessage;
  *
  * @method onStart(Consumer $self)
  * @method onConsume(Consumer $self, AMQPMessage $msg)
+ * @method onConsumeStop(Consumer $self, AMQPMessage $msg)
  * @method onReject(Consumer $self, AMQPMessage $msg, $processFlag)
  * @method onAck(Consumer $self, AMQPMessage $msg)
  * @method onError(Consumer $self, AMQPExceptionInterface $e)
@@ -26,6 +27,11 @@ class Consumer extends BaseConsumer
 	 * @var array
 	 */
 	public $onConsume = array();
+
+	/**
+	 * @var array
+	 */
+	public $onConsumeStop = array();
 
 	/**
 	 * @var array
@@ -146,6 +152,7 @@ class Consumer extends BaseConsumer
 		try {
 			$processFlag = call_user_func($this->callback, $msg);
 			$this->handleProcessMessage($msg, $processFlag);
+			$this->onConsumeStop($this, $msg);
 
 		} catch (\Exception $e) {
 			$this->onReject($this, $msg, IConsumer::MSG_REJECT_REQUEUE);


### PR DESCRIPTION
Currently signals are not dispatched when consumer is idle.

Since the `waits` for rabbitmq are blocking, `pcntl_signal_dispatch` can never be called. This fix registers signal handlers only for the task processing itself and then returns the original system handlers.

Test plans:

1. Run consumer on empty queue. Try killing the consumer with `INT`. Before this patch, it will not terminate.
2. Run consumer on queue with one task. After the task is processed, try killing the consumer with `INT`. Before this patch, it will not terminate.

Caveats:
- On many very short tasks the signal handling creates a considerable overhead (1000 -> 12ms) https://gist.github.com/Mikulas/8fcb7c30fe340f98c8d5
