### PR TITLE
TerminateAndRequeueException

### DIFF
--- a/src/Kdyby/RabbitMq/Consumer.php
+++ b/src/Kdyby/RabbitMq/Consumer.php
@@ -125,6 +125,9 @@ class Consumer extends BaseConsumer
 
 			$this->onError($this, $e);
 			throw $e;
+
+		} catch (TerminateAndRequeueException $e) {
+			$this->stopConsuming();
 		}
 	}
 
@@ -146,6 +149,10 @@ class Consumer extends BaseConsumer
 		try {
 			$processFlag = call_user_func($this->callback, $msg);
 			$this->handleProcessMessage($msg, $processFlag);
+
+		} catch (TerminateAndRequeueException $e) {
+			$this->handleProcessMessage($msg, IConsumer::MSG_REJECT_REQUEUE);
+			throw $e;
 
 		} catch (\Exception $e) {
 			$this->onReject($this, $msg, IConsumer::MSG_REJECT_REQUEUE);

--- a/src/Kdyby/RabbitMq/exceptions.php
+++ b/src/Kdyby/RabbitMq/exceptions.php
@@ -32,3 +32,10 @@ class QueueNotFoundException extends \RuntimeException implements Exception
 {
 
 }
+
+
+
+class TerminateAndRequeueException extends \RuntimeException implements Exception
+{
+
+}


### PR DESCRIPTION
Introduces TerminateAndRequeueException which allows user callbacks to tell Consumer to requeue current message & gracefully exit.

It is usefull when you manage your consumers by supervisord (or alike), you encounter unrecoverable error during message processing and need to completely try again (e.g. Doctrine locked entities).