### PR TITLE
Don't bind queue if exchange is not defined in configuration. 

### DIFF
--- a/src/Kdyby/RabbitMq/AmqpMember.php
+++ b/src/Kdyby/RabbitMq/AmqpMember.php
@@ -257,7 +257,9 @@ abstract class AmqpMember extends Nette\Object
 		);
 
 		if (empty($options['routing_keys'])) {
-			$this->getChannel()->queue_bind($queueName, $this->exchangeOptions['name'], $this->routingKey);
+			if (!empty($this->exchangeOptions['name'])) {
+				$this->getChannel()->queue_bind($queueName, $this->exchangeOptions['name'], $this->routingKey);
+			}
 
 		} else {
 			foreach ($options['routing_keys'] as $routingKey) {


### PR DESCRIPTION
It should be possible don't specify exchange in config. 
Thus use for that cosumer/producer default RabbitMq exchange.

RabbitMq forbids to bind queue to default exchange. 

Running cosumer with configuration like this
```
rabbit:
    consumers:
        zippy:
            queue: {name: 'zippy'}
            callback: @\App\Model\RabbitConsumer::zippy
```

Ends with error 

```
  [PhpAmqpLib\Exception\AMQPProtocolChannelException]
  ACCESS_REFUSED - operation not permitted on the default exchange
```
