### PR TITLE
Added timeout option when executing consumer

### DIFF
--- a/docs/en/index.md
+++ b/docs/en/index.md
@@ -238,6 +238,15 @@ In the following example, this flag adds 256 MB memory limit. Consumer will be s
 $ php www/index.php rabbitmq:consumer -l 256
 ```
 
+Sometimes there is a problem with PHP scripts running long time and you can see errors like 'MySQL server has gone away'. 
+You can prevent this by using flag `-t`. In the following example script will be stopped after 10 seconds. 
+It can take longer time to stop script, but no message will be consumed after timeout exceed and script will end.
+
+```bash
+$ php www/index.php rabbitmq:consumer -t 10
+```
+
+
 If you want to remove all the messages awaiting in a queue, you can execute this command to purge this queue:
 
 ```bash

--- a/src/Kdyby/RabbitMq/BaseConsumer.php
+++ b/src/Kdyby/RabbitMq/BaseConsumer.php
@@ -46,6 +46,11 @@ abstract class BaseConsumer extends AmqpMember
 	protected $idleTimeout = 0;
 
 	/**
+	 * @var int $endTime
+	 */
+	protected $endTime;
+
+	/**
 	 * @var array
 	 */
 	protected $qosOptions = array(
@@ -187,6 +192,36 @@ abstract class BaseConsumer extends AmqpMember
 	public function getIdleTimeout()
 	{
 		return $this->idleTimeout;
+	}
+
+
+
+	public function setEndTime($endTime)
+	{
+		$this->endTime = $endTime;
+	}
+
+
+
+	public function getEndTime()
+	{
+		return $this->endTime;
+	}
+
+
+
+	/**
+	 * Checks if elapsed time is greater or equal than time allowed for this process
+	 *
+	 * @return boolean
+	 */
+	protected function isTimeoutExceeded()
+	{
+		if ($this->getEndTime() === NULL) {
+			return FALSE;
+		}
+
+		return (time()) >= ($this->getEndTime());
 	}
 
 }

--- a/src/Kdyby/RabbitMq/Command/BaseConsumerCommand.php
+++ b/src/Kdyby/RabbitMq/Command/BaseConsumerCommand.php
@@ -41,6 +41,7 @@ abstract class BaseConsumerCommand extends Command
 		$this
 			->addArgument('name', InputArgument::REQUIRED, 'Consumer Name')
 			->addOption('messages', 'm', InputOption::VALUE_OPTIONAL, 'Messages to consume', 0)
+			->addOption('timeout', 't', InputOption::VALUE_OPTIONAL, 'Timeout in seconds')
 			->addOption('route', 'r', InputOption::VALUE_OPTIONAL, 'Routing Key', '')
 			->addOption('memory-limit', 'l', InputOption::VALUE_OPTIONAL, 'Allowed memory for this process', null)
 			->addOption('debug', 'd', InputOption::VALUE_NONE, 'Enable Debugging')
@@ -86,6 +87,14 @@ abstract class BaseConsumerCommand extends Command
 
 		if (!is_null($input->getOption('memory-limit')) && ctype_digit((string) $input->getOption('memory-limit')) && $input->getOption('memory-limit') > 0) {
 			$this->consumer->setMemoryLimit($input->getOption('memory-limit'));
+		}
+
+		if (!is_null($input->getOption('timeout'))) {
+			if (ctype_digit((string)$input->getOption('timeout')) && $input->getOption('timeout') > 0) {
+				$this->consumer->setEndTime(time() + $input->getOption('timeout') - 1);
+			} else {
+				throw new \InvalidArgumentException("The -t option should be null or integer greater than 0");
+			}
 		}
 
 		if ($routingKey = $input->getOption('route')) {


### PR DESCRIPTION
Hi, I've added timeout option for consumers. In the following example consumer will end after 10 seconds:

```
php www/index.php rabbitmq:consumer -t 10 myConsumer
```

I've added it because I need to limit how long are consumers running. I've tried option `-m` but it doesn't wirk when queue is empty. Currently i run php with max_execution_time option but it is not a good solution.