### PR TITLE
Remove unnecessary purge() argument

### DIFF
--- a/src/Kdyby/RabbitMq/Command/PurgeConsumerCommand.php
+++ b/src/Kdyby/RabbitMq/Command/PurgeConsumerCommand.php
@@ -58,7 +58,7 @@ class PurgeConsumerCommand extends Command
 
 		/** @var Consumer $consumer */
 		$consumer = $this->connection->getConsumer($input->getArgument('name'));
-		$consumer->purge($input->getArgument('name'));
+		$consumer->purge();
 
 		return 0;
 	}


### PR DESCRIPTION
* `Consumer#purge()` method takes no arguments.

**Requires** https://github.com/Kdyby/RabbitMq/pull/33