### PR TITLE
Fix: Whitespace code-sniff failure

### DIFF
--- a/tests/Command/BaseCommandTest.php
+++ b/tests/Command/BaseCommandTest.php
@@ -4,26 +4,26 @@ namespace OldSound\RabbitMqBundle\Tests\Command;
 
 abstract class BaseCommandTest extends \PHPUnit_Framework_TestCase
 {
-    protected $application;
-    protected $definition;
-    protected $helperSet;
-    protected $command;
+	protected $application;
+	protected $definition;
+	protected $helperSet;
+	protected $command;
 
-    protected function setUp()
-    {
-        $this->application = $this->getMockBuilder('Symfony\\Bundle\\FrameworkBundle\\Console\\Application')
-            ->disableOriginalConstructor()
-            ->getMock();
-        $this->definition = $this->getMockBuilder('Symfony\\Component\\Console\\Input\\InputDefinition')
-            ->disableOriginalConstructor()
-            ->getMock();
-        $this->helperSet = $this->getMock('Symfony\\Component\\Console\\Helper\\HelperSet');
+	protected function setUp()
+	{
+		$this->application = $this->getMockBuilder('Symfony\\Bundle\\FrameworkBundle\\Console\\Application')
+			->disableOriginalConstructor()
+			->getMock();
+		$this->definition = $this->getMockBuilder('Symfony\\Component\\Console\\Input\\InputDefinition')
+			->disableOriginalConstructor()
+			->getMock();
+		$this->helperSet = $this->getMock('Symfony\\Component\\Console\\Helper\\HelperSet');
 
-        $this->application->expects($this->any())
-            ->method('getDefinition')
-            ->will($this->returnValue($this->definition));
-        $this->definition->expects($this->any())
-            ->method('getArguments')
-            ->will($this->returnValue(array()));
-    }
+		$this->application->expects($this->any())
+			->method('getDefinition')
+			->will($this->returnValue($this->definition));
+		$this->definition->expects($this->any())
+			->method('getArguments')
+			->will($this->returnValue(array()));
+	}
 }

--- a/tests/Command/ConsumerCommandTest.php
+++ b/tests/Command/ConsumerCommandTest.php
@@ -8,44 +8,44 @@ use Symfony\Component\Console\Input\InputOption;
 
 class ConsumerCommandTest extends BaseCommandTest
 {
-    protected function setUp()
-    {
-        parent::setUp();
-        $this->definition->expects($this->any())
-            ->method('getOptions')
-            ->will($this->returnValue(array(
-                new InputOption('--verbose', '-v', InputOption::VALUE_NONE, 'Increase verbosity of messages.'),
-                new InputOption('--env', '-e', InputOption::VALUE_REQUIRED, 'The Environment name.', 'dev'),
-                new InputOption('--no-debug', null, InputOption::VALUE_NONE, 'Switches off debug mode.'),
-            )));
-        $this->application->expects($this->once())
-            ->method('getHelperSet')
-            ->will($this->returnValue($this->helperSet));
+	protected function setUp()
+	{
+		parent::setUp();
+		$this->definition->expects($this->any())
+			->method('getOptions')
+			->will($this->returnValue(array(
+				new InputOption('--verbose', '-v', InputOption::VALUE_NONE, 'Increase verbosity of messages.'),
+				new InputOption('--env', '-e', InputOption::VALUE_REQUIRED, 'The Environment name.', 'dev'),
+				new InputOption('--no-debug', null, InputOption::VALUE_NONE, 'Switches off debug mode.'),
+			)));
+		$this->application->expects($this->once())
+			->method('getHelperSet')
+			->will($this->returnValue($this->helperSet));
 
-        $this->command = new ConsumerCommand();
-        $this->command->setApplication($this->application);
-    }
+		$this->command = new ConsumerCommand();
+		$this->command->setApplication($this->application);
+	}
 
-    /**
-     * testInputsDefinitionCommand
-     */
-    public function testInputsDefinitionCommand()
-    {
-        // check argument
-        $this->assertTrue($this->command->getDefinition()->hasArgument('name'));
-        $this->assertTrue($this->command->getDefinition()->getArgument('name')->isRequired()); // Name is required to find the service
+	/**
+	 * testInputsDefinitionCommand
+	 */
+	public function testInputsDefinitionCommand()
+	{
+		// check argument
+		$this->assertTrue($this->command->getDefinition()->hasArgument('name'));
+		$this->assertTrue($this->command->getDefinition()->getArgument('name')->isRequired()); // Name is required to find the service
 
-        //check options
-        $this->assertTrue($this->command->getDefinition()->hasOption('messages'));
-        $this->assertTrue($this->command->getDefinition()->getOption('messages')->isValueOptional()); // It should accept value
+		//check options
+		$this->assertTrue($this->command->getDefinition()->hasOption('messages'));
+		$this->assertTrue($this->command->getDefinition()->getOption('messages')->isValueOptional()); // It should accept value
 
-        $this->assertTrue($this->command->getDefinition()->hasOption('route'));
-        $this->assertTrue($this->command->getDefinition()->getOption('route')->isValueOptional()); // It should accept value
+		$this->assertTrue($this->command->getDefinition()->hasOption('route'));
+		$this->assertTrue($this->command->getDefinition()->getOption('route')->isValueOptional()); // It should accept value
 
-        $this->assertTrue($this->command->getDefinition()->hasOption('without-signals'));
-        $this->assertFalse($this->command->getDefinition()->getOption('without-signals')->acceptValue()); // It shouldn't accept value because it is a true/false input
+		$this->assertTrue($this->command->getDefinition()->hasOption('without-signals'));
+		$this->assertFalse($this->command->getDefinition()->getOption('without-signals')->acceptValue()); // It shouldn't accept value because it is a true/false input
 
-        $this->assertTrue($this->command->getDefinition()->hasOption('debug'));
-        $this->assertFalse($this->command->getDefinition()->getOption('debug')->acceptValue()); // It shouldn't accept value because it is a true/false input
-    }
+		$this->assertTrue($this->command->getDefinition()->hasOption('debug'));
+		$this->assertFalse($this->command->getDefinition()->getOption('debug')->acceptValue()); // It shouldn't accept value because it is a true/false input
+	}
 }

--- a/tests/Command/PurgeCommandTest.php
+++ b/tests/Command/PurgeCommandTest.php
@@ -9,33 +9,33 @@ use Symfony\Component\Console\Input\InputOption;
 
 class PurgeCommandTest extends BaseCommandTest
 {
-    protected function setUp()
-    {
-        parent::setUp();
-        $this->definition->expects($this->any())
-            ->method('getOptions')
-            ->will($this->returnValue(array(
-                new InputOption('--no-confirmation', null, InputOption::VALUE_NONE, 'Switches off confirmation mode.'),
-            )));
-        $this->application->expects($this->once())
-            ->method('getHelperSet')
-            ->will($this->returnValue($this->helperSet));
+	protected function setUp()
+	{
+		parent::setUp();
+		$this->definition->expects($this->any())
+			->method('getOptions')
+			->will($this->returnValue(array(
+				new InputOption('--no-confirmation', null, InputOption::VALUE_NONE, 'Switches off confirmation mode.'),
+			)));
+		$this->application->expects($this->once())
+			->method('getHelperSet')
+			->will($this->returnValue($this->helperSet));
 
-        $this->command = new PurgeConsumerCommand();
-        $this->command->setApplication($this->application);
-    }
+		$this->command = new PurgeConsumerCommand();
+		$this->command->setApplication($this->application);
+	}
 
-    /**
-     * testInputsDefinitionCommand
-     */
-    public function testInputsDefinitionCommand()
-    {
-        // check argument
-        $this->assertTrue($this->command->getDefinition()->hasArgument('name'));
-        $this->assertTrue($this->command->getDefinition()->getArgument('name')->isRequired()); // Name is required to find the service
+	/**
+	 * testInputsDefinitionCommand
+	 */
+	public function testInputsDefinitionCommand()
+	{
+		// check argument
+		$this->assertTrue($this->command->getDefinition()->hasArgument('name'));
+		$this->assertTrue($this->command->getDefinition()->getArgument('name')->isRequired()); // Name is required to find the service
 
-        //check options
-        $this->assertTrue($this->command->getDefinition()->hasOption('no-confirmation'));
-        $this->assertFalse($this->command->getDefinition()->getOption('no-confirmation')->acceptValue()); // It shouldn't accept value because it is a true/false input
-    }
+		//check options
+		$this->assertTrue($this->command->getDefinition()->hasOption('no-confirmation'));
+		$this->assertFalse($this->command->getDefinition()->getOption('no-confirmation')->acceptValue()); // It shouldn't accept value because it is a true/false input
+	}
 }

--- a/tests/RabbitMq/MultipleConsumerTest.php
+++ b/tests/RabbitMq/MultipleConsumerTest.php
@@ -8,58 +8,58 @@ use PhpAmqpLib\Message\AMQPMessage;
 
 class MultipleConsumerTest extends \PHPUnit_Framework_TestCase
 {
-    /**
-     * Check if the message is requeued or not correctly.
-     *
-     * @dataProvider processMessageProvider
-     */
-    public function testProcessMessage($processFlag, $expectedMethod, $expectedRequeue = null)
-    {
-        $amqpConnection = $this->getMockBuilder('\PhpAmqpLib\Connection\AMQPConnection')
-            ->disableOriginalConstructor()
-            ->getMock();
+	/**
+	 * Check if the message is requeued or not correctly.
+	 *
+	 * @dataProvider processMessageProvider
+	 */
+	public function testProcessMessage($processFlag, $expectedMethod, $expectedRequeue = null)
+	{
+		$amqpConnection = $this->getMockBuilder('\PhpAmqpLib\Connection\AMQPConnection')
+			->disableOriginalConstructor()
+			->getMock();
 
-        $amqpChannel = $this->getMockBuilder('\PhpAmqpLib\Channel\AMQPChannel')
-            ->disableOriginalConstructor()
-            ->getMock();
+		$amqpChannel = $this->getMockBuilder('\PhpAmqpLib\Channel\AMQPChannel')
+			->disableOriginalConstructor()
+			->getMock();
 
-        $consumer = new MultipleConsumer($amqpConnection, $amqpChannel);
-        $callback = function($msg) use (&$lastQueue, $processFlag) {
-            return $processFlag;
-        };
+		$consumer = new MultipleConsumer($amqpConnection, $amqpChannel);
+		$callback = function($msg) use (&$lastQueue, $processFlag) {
+			return $processFlag;
+		};
 
-        $consumer->setQueues(array('test-1' => array('callback' => $callback), 'test-2'  => array('callback' => $callback)));
+		$consumer->setQueues(array('test-1' => array('callback' => $callback), 'test-2'  => array('callback' => $callback)));
 
-        // Create a default message
-        $amqpMessage = new AMQPMessage('foo body');
-        $amqpMessage->delivery_info['channel'] = $amqpChannel;
-        $amqpMessage->delivery_info['delivery_tag'] = 0;
-        $amqpChannel->expects($this->any())
-            ->method('basic_reject')
-            ->will($this->returnCallback(function($delivery_tag, $requeue) use ($expectedMethod, $expectedRequeue) {
-                \PHPUnit_Framework_Assert::assertSame($expectedMethod, 'basic_reject'); // Check if this function should be called.
-                \PHPUnit_Framework_Assert::assertSame($requeue, $expectedRequeue); // Check if the message should be requeued.
-            }));
+		// Create a default message
+		$amqpMessage = new AMQPMessage('foo body');
+		$amqpMessage->delivery_info['channel'] = $amqpChannel;
+		$amqpMessage->delivery_info['delivery_tag'] = 0;
+		$amqpChannel->expects($this->any())
+			->method('basic_reject')
+			->will($this->returnCallback(function($delivery_tag, $requeue) use ($expectedMethod, $expectedRequeue) {
+				\PHPUnit_Framework_Assert::assertSame($expectedMethod, 'basic_reject'); // Check if this function should be called.
+				\PHPUnit_Framework_Assert::assertSame($requeue, $expectedRequeue); // Check if the message should be requeued.
+			}));
 
-        $amqpChannel->expects($this->any())
-            ->method('basic_ack')
-            ->will($this->returnCallback(function($delivery_tag) use ($expectedMethod) {
-                \PHPUnit_Framework_Assert::assertSame($expectedMethod, 'basic_ack'); // Check if this function should be called.
-            }));
+		$amqpChannel->expects($this->any())
+			->method('basic_ack')
+			->will($this->returnCallback(function($delivery_tag) use ($expectedMethod) {
+				\PHPUnit_Framework_Assert::assertSame($expectedMethod, 'basic_ack'); // Check if this function should be called.
+			}));
 
-        $consumer->processQueueMessage('test-1', $amqpMessage);
-        $consumer->processQueueMessage('test-2', $amqpMessage);
-    }
+		$consumer->processQueueMessage('test-1', $amqpMessage);
+		$consumer->processQueueMessage('test-2', $amqpMessage);
+	}
 
-    public function processMessageProvider()
-    {
-        return array(
-            array(null, 'basic_ack'), // Remove message from queue only if callback return not false
-            array(true, 'basic_ack'), // Remove message from queue only if callback return not false
-            array(false, 'basic_reject', true), // Reject and requeue message to RabbitMQ
-            array(ConsumerInterface::MSG_ACK, 'basic_ack'), // Remove message from queue only if callback return not false
-            array(ConsumerInterface::MSG_REJECT_REQUEUE, 'basic_reject', true), // Reject and requeue message to RabbitMQ
-            array(ConsumerInterface::MSG_REJECT, 'basic_reject', false), // Reject and drop
-        );
-    }
+	public function processMessageProvider()
+	{
+		return array(
+			array(null, 'basic_ack'), // Remove message from queue only if callback return not false
+			array(true, 'basic_ack'), // Remove message from queue only if callback return not false
+			array(false, 'basic_reject', true), // Reject and requeue message to RabbitMQ
+			array(ConsumerInterface::MSG_ACK, 'basic_ack'), // Remove message from queue only if callback return not false
+			array(ConsumerInterface::MSG_REJECT_REQUEUE, 'basic_reject', true), // Reject and requeue message to RabbitMQ
+			array(ConsumerInterface::MSG_REJECT, 'basic_reject', false), // Reject and drop
+		);
+	}
 }


### PR DESCRIPTION
* A few tests were using spaces instead of tabs.
* Tabs are used throughout the project.
* Convert spacing to tabs.