### PR TITLE
Allow to set default routing key for producer.

### DIFF
--- a/docs/en/index.md
+++ b/docs/en/index.md
@@ -147,6 +147,15 @@ Besides the message itself, the `Kdyby\RabbitMq\Producer::publish()` method also
 The array of additional properties allows you to alter the properties with which an `PhpAmqpLib\Message\AMQPMessage` object gets constructed by default.
 This way, for example, you can change the application headers.
 
+You are able to set default routing key in producer. You can provide it by `setRoutingKey` method or in configuration like bellow. Default routing key will be used for calls of `publish` method without second parrameter, or when second parameter is set to `NULL`. Be aware of setting second parameter to empty string, which is considered as "send without routing key". 
+```yaml
+	...
+	producers:
+		uploadPicture:
+			routingKey: iphone.upload
+	...
+```
+
 You can use `setContentType` and `setDeliveryMode` methods in order to set the message content type and the message
 delivery mode respectively. Default values are `text/plain` for content type and `2` for delivery mode.
 

--- a/docs/en/index.md
+++ b/docs/en/index.md
@@ -148,6 +148,7 @@ The array of additional properties allows you to alter the properties with which
 This way, for example, you can change the application headers.
 
 You are able to set default routing key in producer. You can provide it by `setRoutingKey` method or in configuration like bellow. Default routing key will be used for calls of `publish` method without second parrameter, or when second parameter is set to `NULL`. Be aware of setting second parameter to empty string, which is considered as "send without routing key". 
+
 ```yaml
 	...
 	producers:

--- a/docs/en/index.md
+++ b/docs/en/index.md
@@ -147,7 +147,7 @@ Besides the message itself, the `Kdyby\RabbitMq\Producer::publish()` method also
 The array of additional properties allows you to alter the properties with which an `PhpAmqpLib\Message\AMQPMessage` object gets constructed by default.
 This way, for example, you can change the application headers.
 
-You are able to set default routing key in producer. You can provide it by `setRoutingKey` method or in configuration like bellow. Default routing key will be used for calls of `publish` method without second parrameter, or when second parameter is set to `NULL`. Be aware of setting second parameter to empty string, which is considered as "send without routing key". 
+You can set default routing key in producer context. You can provide it by `setRoutingKey` method or in configuration like bellow. Default routing key will be used in `publish` method calls with second argument ommited or set to `NULL`. Be aware, that setting second argument to empty string will lead to send empty string as routing key.
 
 ```yaml
 	...

--- a/src/Kdyby/RabbitMq/DI/RabbitMqExtension.php
+++ b/src/Kdyby/RabbitMq/DI/RabbitMqExtension.php
@@ -285,7 +285,7 @@ class RabbitMqExtension extends Nette\DI\CompilerExtension
 				->setClass('Kdyby\RabbitMq\IProducer')
 				->addSetup('setContentType', [$config['contentType']])
 				->addSetup('setDeliveryMode', [$config['deliveryMode']])
-                ->addSetup('setRoutingKey', array($config['routingKey']))
+				->addSetup('setRoutingKey', array($config['routingKey']))
 				->addTag(self::TAG_PRODUCER);
 
 			if (!empty($config['exchange'])) {

--- a/src/Kdyby/RabbitMq/DI/RabbitMqExtension.php
+++ b/src/Kdyby/RabbitMq/DI/RabbitMqExtension.php
@@ -65,6 +65,7 @@ class RabbitMqExtension extends Nette\DI\CompilerExtension
 		'queue' => [],
 		'contentType' => 'text/plain',
 		'deliveryMode' => 2,
+        'routingKey' => '',
 		'autoSetupFabric' => NULL, // inherits from `rabbitmq: autoSetupFabric:`
 	];
 
@@ -284,6 +285,7 @@ class RabbitMqExtension extends Nette\DI\CompilerExtension
 				->setClass('Kdyby\RabbitMq\IProducer')
 				->addSetup('setContentType', [$config['contentType']])
 				->addSetup('setDeliveryMode', [$config['deliveryMode']])
+                ->addSetup('setRoutingKey', array($config['routingKey']))
 				->addTag(self::TAG_PRODUCER);
 
 			if (!empty($config['exchange'])) {

--- a/src/Kdyby/RabbitMq/DI/RabbitMqExtension.php
+++ b/src/Kdyby/RabbitMq/DI/RabbitMqExtension.php
@@ -65,7 +65,7 @@ class RabbitMqExtension extends Nette\DI\CompilerExtension
 		'queue' => [],
 		'contentType' => 'text/plain',
 		'deliveryMode' => 2,
-        'routingKey' => '',
+		'routingKey' => '',
 		'autoSetupFabric' => NULL, // inherits from `rabbitmq: autoSetupFabric:`
 	];
 
@@ -285,7 +285,7 @@ class RabbitMqExtension extends Nette\DI\CompilerExtension
 				->setClass('Kdyby\RabbitMq\IProducer')
 				->addSetup('setContentType', [$config['contentType']])
 				->addSetup('setDeliveryMode', [$config['deliveryMode']])
-				->addSetup('setRoutingKey', array($config['routingKey']))
+				->addSetup('setRoutingKey', [$config['routingKey']])
 				->addTag(self::TAG_PRODUCER);
 
 			if (!empty($config['exchange'])) {

--- a/src/Kdyby/RabbitMq/Producer.php
+++ b/src/Kdyby/RabbitMq/Producer.php
@@ -49,21 +49,25 @@ class Producer extends AmqpMember implements IProducer
 	}
 
 
+    /**
+     * Publishes the message and merges additional properties with basic properties
+     *
+     * @param string $msgBody
+     * @param string $routingKey IF not provided or set to null, used default routingKey from configuration of this producer
+     * @param array $additionalProperties
+     */
+    public function publish($msgBody, $routingKey = '', $additionalProperties = array())
+    {
+        if ($this->autoSetupFabric) {
+            $this->setupFabric();
+        }
 
-	/**
-	 * Publishes the message and merges additional properties with basic properties
-	 *
-	 * @param string $msgBody
-	 * @param string $routingKey
-	 * @param array $additionalProperties
-	 */
-	public function publish($msgBody, $routingKey = '', $additionalProperties = [])
-	{
-		if ($this->autoSetupFabric) {
-			$this->setupFabric();
-		}
+        if ($this -> routingKey && (func_num_args() <= 1 || $routingKey === NULL)) {
+            // routingKey parameter not provided or set to NULL, use default
+            $routingKey = $this -> routingKey ?: '';
+        }
 
-		$msg = new AMQPMessage((string) $msgBody, array_merge($this->getBasicProperties(), $additionalProperties));
-		$this->getChannel()->basic_publish($msg, $this->exchangeOptions['name'], (string) $routingKey);
-	}
+        $msg = new AMQPMessage((string) $msgBody, array_merge($this->getBasicProperties(), $additionalProperties));
+        $this->getChannel()->basic_publish($msg, $this->exchangeOptions['name'], (string) $routingKey);
+    }
 }

--- a/src/Kdyby/RabbitMq/Producer.php
+++ b/src/Kdyby/RabbitMq/Producer.php
@@ -56,7 +56,7 @@ class Producer extends AmqpMember implements IProducer
      * @param string $routingKey IF not provided or set to null, used default routingKey from configuration of this producer
      * @param array $additionalProperties
      */
-    public function publish($msgBody, $routingKey = '', $additionalProperties = array())
+    public function publish($msgBody, $routingKey = '', $additionalProperties = [])
     {
         if ($this->autoSetupFabric) {
             $this->setupFabric();

--- a/src/Kdyby/RabbitMq/Producer.php
+++ b/src/Kdyby/RabbitMq/Producer.php
@@ -48,26 +48,24 @@ class Producer extends AmqpMember implements IProducer
 		return ['content_type' => $this->contentType, 'delivery_mode' => $this->deliveryMode];
 	}
 
+	/**
+	 * Publishes the message and merges additional properties with basic properties
+	 *
+	 * @param string $msgBody
+	 * @param string $routingKey IF not provided or set to null, used default routingKey from configuration of this producer
+	 * @param array $additionalProperties
+	 */
+	public function publish($msgBody, $routingKey = '', $additionalProperties = [])
+	{
+		if ($this->autoSetupFabric) {
+			$this->setupFabric();
+		}
+		if ($this -> routingKey && (func_num_args() <= 1 || $routingKey === NULL)) {
+			// routingKey parameter not provided or set to NULL, use default
+			$routingKey = $this -> routingKey;
+		}
 
-    /**
-     * Publishes the message and merges additional properties with basic properties
-     *
-     * @param string $msgBody
-     * @param string $routingKey IF not provided or set to null, used default routingKey from configuration of this producer
-     * @param array $additionalProperties
-     */
-    public function publish($msgBody, $routingKey = '', $additionalProperties = [])
-    {
-        if ($this->autoSetupFabric) {
-            $this->setupFabric();
-        }
-
-        if ($this -> routingKey && (func_num_args() <= 1 || $routingKey === NULL)) {
-            // routingKey parameter not provided or set to NULL, use default
-            $routingKey = $this -> routingKey ?: '';
-        }
-
-        $msg = new AMQPMessage((string) $msgBody, array_merge($this->getBasicProperties(), $additionalProperties));
-        $this->getChannel()->basic_publish($msg, $this->exchangeOptions['name'], (string) $routingKey);
-    }
+		$msg = new AMQPMessage((string) $msgBody, array_merge($this->getBasicProperties(), $additionalProperties));
+		$this->getChannel()->basic_publish($msg, $this->exchangeOptions['name'], (string) $routingKey);
+	}
 }


### PR DESCRIPTION
Producers currently had method "setRoutingKey" (from AMQPMember), but this was not used at all. This commit allows to use this parameter as default routing key, instead of need to send it always to publish method.

Also routingKey parameter for producer introduced in config section.

In most use cases, there is application forced to publish with "magic constant" routingKey, which has to be same as routingKeys defined in consumers (for Multiple Consumers).

By allowing to set default routingKey is easy to move from simple Consumer (one per queue) to MultipleConsumer.

Also this commit brings more abstraction, since routingKey in simple cases could remain only in config.neon and there is no need for routingKey in app code.