### PR TITLE
Upgrade to Nette 2.4 to support PHP 7.2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,64 +1,53 @@
 {
-	"name": "kdyby/rabbitmq",
+	"name": "kdyby\/rabbitmq",
 	"type": "library",
 	"description": "Integrates php-amqplib with RabbitMq and Nette Framework",
-	"keywords": ["nette", "kdyby", "rabbitmq", "rabbit", "bunny", "amqp", "messaging", "message", "queue"],
-	"homepage": "http://kdyby.org",
-	"license": ["MIT"],
+	"keywords": [
+		"nette",
+		"kdyby",
+		"rabbitmq",
+		"rabbit",
+		"bunny",
+		"amqp",
+		"messaging",
+		"message",
+		"queue"
+	],
+	"homepage": "http:\/\/kdyby.org",
+	"license": [
+		"MIT"
+	],
 	"authors": [
 		{
 			"name": "Alvaro Videla"
 		},
 		{
-			"name": "Filip Procházka",
-			"homepage": "http://filip-prochazka.com",
+			"name": "Filip Proch\u00e1zka",
+			"homepage": "http:\/\/filip-prochazka.com",
 			"email": "filip@prochazka.su"
 		}
 	],
 	"require": {
 		"php": ">=5.4",
-		"nette/di": "~2.2@dev",
-		"nette/utils": "~2.2@dev",
-
-		"php-amqplib/php-amqplib": "~2.6.2"
+		"nette\/di": "~2.4",
+		"nette\/utils": "~2.4",
+		"php-amqplib\/php-amqplib": "~2.6.2"
 	},
 	"require-dev": {
-		"nette/application": "~2.3@dev",
-		"nette/bootstrap": "~2.3@dev",
-		"nette/caching": "~2.3@dev",
-		"nette/component-model": "~2.2@dev",
-		"nette/database": "~2.3@dev",
-		"nette/deprecated": "~2.2@dev",
-		"nette/di": "~2.3@dev",
-		"nette/finder": "~2.3@dev",
-		"nette/forms": "~2.3@dev",
-		"nette/http": "~2.3@dev",
-		"nette/mail": "~2.3@dev",
-		"nette/neon": "~2.3@dev",
-		"nette/php-generator": "~2.3@dev",
-		"nette/reflection": "~2.3@dev",
-		"nette/robot-loader": "~2.3@dev",
-		"nette/safe-stream": "~2.3@dev",
-		"nette/security": "~2.3@dev",
-		"nette/tokenizer": "~2.2@dev",
-		"nette/utils": "~2.3@dev",
-		"latte/latte": "~2.3@dev",
-		"tracy/tracy": "~2.3@dev",
-
-		"nette/tester": "~1.3@rc",
-		"mockery/mockery": "~0.9.1",
-		"kdyby/console": "~2.3@dev"
+		"nette\/tester": "~1.3@rc",
+		"mockery\/mockery": "~0.9.1",
+		"kdyby\/console": "~2.3@dev"
 	},
 	"support": {
 		"email": "filip@prochazka.su",
-		"issues": "https://github.com/Kdyby/RabbitMq/issues"
+		"issues": "https:\/\/github.com\/Kdyby\/RabbitMq\/issues"
 	},
 	"autoload": {
 		"psr-0": {
-			"Kdyby\\RabbitMq\\": "src/"
+			"Kdyby\\RabbitMq\\": "src\/"
 		},
 		"classmap": [
-			"src/Kdyby/RabbitMq/exceptions.php"
+			"src\/Kdyby\/RabbitMq\/exceptions.php"
 		]
 	},
 	"extra": {

--- a/composer.json
+++ b/composer.json
@@ -1,53 +1,41 @@
 {
-	"name": "kdyby\/rabbitmq",
+	"name": "kdyby/rabbitmq",
 	"type": "library",
 	"description": "Integrates php-amqplib with RabbitMq and Nette Framework",
-	"keywords": [
-		"nette",
-		"kdyby",
-		"rabbitmq",
-		"rabbit",
-		"bunny",
-		"amqp",
-		"messaging",
-		"message",
-		"queue"
-	],
-	"homepage": "http:\/\/kdyby.org",
-	"license": [
-		"MIT"
-	],
+	"keywords": ["nette", "kdyby", "rabbitmq", "rabbit", "bunny", "amqp", "messaging", "message", "queue"],
+	"homepage": "http://kdyby.org",
+	"license": ["MIT"],
 	"authors": [
 		{
 			"name": "Alvaro Videla"
 		},
 		{
-			"name": "Filip Proch\u00e1zka",
-			"homepage": "http:\/\/filip-prochazka.com",
+			"name": "Filip Procházka",
+			"homepage": "http://filip-prochazka.com",
 			"email": "filip@prochazka.su"
 		}
 	],
 	"require": {
 		"php": ">=5.4",
-		"nette\/di": "~2.4",
-		"nette\/utils": "~2.4",
-		"php-amqplib\/php-amqplib": "~2.6.2"
+		"nette/di": "~2.4",
+		"nette/utils": "~2.4",
+		"php-amqplib/php-amqplib": "~2.6.2"
 	},
 	"require-dev": {
-		"nette\/tester": "~1.3@rc",
-		"mockery\/mockery": "~0.9.1",
-		"kdyby\/console": "~2.3@dev"
+		"nette/tester": "~1.3@rc",
+		"mockery/mockery": "~0.9.1",
+		"kdyby/console": "~2.3@dev"
 	},
 	"support": {
 		"email": "filip@prochazka.su",
-		"issues": "https:\/\/github.com\/Kdyby\/RabbitMq\/issues"
+		"issues": "https://github.com\/Kdyby\/RabbitMq\/issues"
 	},
 	"autoload": {
 		"psr-0": {
-			"Kdyby\\RabbitMq\\": "src\/"
+			"Kdyby\\RabbitMq\\": "src/"
 		},
 		"classmap": [
-			"src\/Kdyby\/RabbitMq\/exceptions.php"
+			"src/Kdyby/RabbitMq/exceptions.php"
 		]
 	},
 	"extra": {

--- a/src/Kdyby/RabbitMq/AmqpMember.php
+++ b/src/Kdyby/RabbitMq/AmqpMember.php
@@ -14,9 +14,13 @@ use PhpAmqpLib\Connection\AMQPLazyConnection;
  *
  * @property array $exchangeOptions
  * @property array $queueOptions
+ * @property AMQPChannel $channel
+ * @property-write string $routingKey
  */
-abstract class AmqpMember extends Nette\Object
+abstract class AmqpMember
 {
+
+    use Nette\SmartObject;
 
 	/**
 	 * @var Connection

--- a/src/Kdyby/RabbitMq/BaseConsumer.php
+++ b/src/Kdyby/RabbitMq/BaseConsumer.php
@@ -11,6 +11,10 @@ use Nette\Utils\Callback;
  * @author Filip Procházka <filip@prochazka.su>
  *
  * @method onStop(BaseConsumer $self)
+ *
+ * @property string $consumerTag
+ * @property int $idleTimeout
+ * @property-write callable $callback
  */
 abstract class BaseConsumer extends AmqpMember
 {

--- a/src/Kdyby/RabbitMq/Consumer.php
+++ b/src/Kdyby/RabbitMq/Consumer.php
@@ -19,6 +19,8 @@ use PhpAmqpLib\Message\AMQPMessage;
  * @method onAck(Consumer $self, AMQPMessage $msg)
  * @method onError(Consumer $self, AMQPExceptionInterface $e)
  * @method onTimeout(Consumer $self)
+ *
+ * @property int $memoryLimit
  */
 class Consumer extends BaseConsumer
 {

--- a/src/Kdyby/RabbitMq/Diagnostics/Panel.php
+++ b/src/Kdyby/RabbitMq/Diagnostics/Panel.php
@@ -25,8 +25,10 @@ use Tracy\IBarPanel;
  * @property callable $failure
  * @property callable $success
  */
-class Panel extends Nette\Object implements IBarPanel
+class Panel implements IBarPanel
 {
+
+    use Nette\SmartObject;
 
 	/**
 	 * @var array

--- a/src/Kdyby/RabbitMq/MultipleConsumer.php
+++ b/src/Kdyby/RabbitMq/MultipleConsumer.php
@@ -10,6 +10,8 @@ use PhpAmqpLib\Message\AMQPMessage;
 /**
  * @author Alvaro Videla <videlalvaro@gmail.com>
  * @author Filip Procházka <filip@prochazka.su>
+ *
+ * @property array[]|callable[][] $queues
  */
 class MultipleConsumer extends Consumer
 {

--- a/src/Kdyby/RabbitMq/Producer.php
+++ b/src/Kdyby/RabbitMq/Producer.php
@@ -9,6 +9,9 @@ use PhpAmqpLib\Message\AMQPMessage;
 /**
  * @author Alvaro Videla <videlalvaro@gmail.com>
  * @author Filip Procházka <filip@prochazka.su>
+ *
+ * @property string $contentType
+ * @property string $deliveryMode
  */
 class Producer extends AmqpMember implements IProducer
 {

--- a/src/Kdyby/RabbitMq/RpcClient.php
+++ b/src/Kdyby/RabbitMq/RpcClient.php
@@ -9,6 +9,8 @@ use PhpAmqpLib\Message\AMQPMessage;
 /**
  * @author Alvaro Videla <videlalvaro@gmail.com>
  * @author Filip Procházka <filip@prochazka.su>
+ *
+ * @property array $replies
  */
 class RpcClient extends AmqpMember
 {


### PR DESCRIPTION
Adresses https://github.com/Kdyby/RabbitMq/issues/62

This is BC breaking pull.

As Nette\SmartObject were introduced in Nette 2.4, older versions will not be supported after this upgrade. I would recomend create nette-2.3 branch from current master before pull request acceptance.