### PR TITLE
Deprecated Nette\Object in Nette\Utils @ v2.5

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
+.idea
 vendor
 composer.lock

--- a/src/Kdyby/RabbitMq/AmqpMember.php
+++ b/src/Kdyby/RabbitMq/AmqpMember.php
@@ -2,7 +2,7 @@
 
 namespace Kdyby\RabbitMq;
 
-use Nette;
+use Nette\SmartObject;
 use PhpAmqpLib\Channel\AMQPChannel;
 use PhpAmqpLib\Connection\AMQPLazyConnection;
 
@@ -17,7 +17,7 @@ use PhpAmqpLib\Connection\AMQPLazyConnection;
  */
 abstract class AmqpMember
 {
-    use Nette\SmartObject;
+    use SmartObject;
 
 	/**
 	 * @var Connection

--- a/src/Kdyby/RabbitMq/AmqpMember.php
+++ b/src/Kdyby/RabbitMq/AmqpMember.php
@@ -15,8 +15,9 @@ use PhpAmqpLib\Connection\AMQPLazyConnection;
  * @property array $exchangeOptions
  * @property array $queueOptions
  */
-abstract class AmqpMember extends Nette\Object
+abstract class AmqpMember
 {
+    use Nette\SmartObject;
 
 	/**
 	 * @var Connection

--- a/src/Kdyby/RabbitMq/Diagnostics/Panel.php
+++ b/src/Kdyby/RabbitMq/Diagnostics/Panel.php
@@ -25,8 +25,10 @@ use Tracy\IBarPanel;
  * @property callable $failure
  * @property callable $success
  */
-class Panel extends Nette\Object implements IBarPanel
+class Panel implements IBarPanel
 {
+
+    use Nette\SmartObject;
 
 	/**
 	 * @var array

--- a/src/Kdyby/RabbitMq/Diagnostics/Panel.php
+++ b/src/Kdyby/RabbitMq/Diagnostics/Panel.php
@@ -11,7 +11,7 @@
 namespace Kdyby\RabbitMq\Diagnostics;
 
 use Kdyby\RabbitMq\Connection;
-use Nette;
+use Nette\SmartObject;
 use Nette\Utils\Html;
 use Tracy\Debugger;
 use Tracy\IBarPanel;
@@ -28,7 +28,7 @@ use Tracy\IBarPanel;
 class Panel implements IBarPanel
 {
 
-    use Nette\SmartObject;
+    use SmartObject;
 
 	/**
 	 * @var array


### PR DESCRIPTION
Hello,

in Nette\Utils v2.5 was deprecated Nette\Object (`class SomeClass extends \Nette\Object`) causing an error.

It was replaced with trait Nette\SmartObject.

Nothing big, just tiny patch. I hope it saves some time for others :)