### PR TITLE
Dev version 4

### DIFF
--- a/.github/workflows/php-package-ci.yml
+++ b/.github/workflows/php-package-ci.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php: [ 7.4, 8.0, 8.1 ]
+        php: [ 8.2, 8.3, 8.4 ]
     steps:
       - uses: actions/checkout@v2
       - uses: shivammathur/setup-php@v2
@@ -17,7 +17,7 @@ jobs:
           php-version: ${{ matrix.php }}
       - uses: getong/rabbitmq-action@v1.2
         with:
-          rabbitmq version: '3.9.5-management-alpine'
+          rabbitmq version: '4.1.1-management-alpine'
           host port: 5672
           rabbitmq user: 'guest'
           rabbitmq password: 'guest'

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ lint:
 	vendor/bin/parallel-lint -e php,phpt --exclude vendor .
 
 phpstan:
-	vendor/bin/phpstan analyse -l 2 -c phpstan.neon src tests/KdybyTests
+	vendor/bin/phpstan analyse -c phpstan.neon --no-progress --no-ansi --memory-limit=-1
 
 run-tests:
 	vendor/bin/tester -s -c ./tests/php.ini-unix ./tests/KdybyTests/

--- a/composer.json
+++ b/composer.json
@@ -20,6 +20,7 @@
 		"nette/di": "^3.0",
 		"nette/utils": "^3.0",
 		"php-amqplib/php-amqplib": "~3.1.0"
+		"php-amqplib/php-amqplib": "~3.7.2"
 	},
 	"require-dev": {
 		"kdyby/console": "~2.8",

--- a/composer.json
+++ b/composer.json
@@ -18,22 +18,21 @@
 	"require": {
 		"php": "^8.2",
 		"nette/di": "^3.0",
-		"nette/utils": "^3.0",
-		"php-amqplib/php-amqplib": "~3.1.0"
+		"nette/utils": "^4.0",
 		"php-amqplib/php-amqplib": "~3.7.2"
 	},
 	"require-dev": {
 		"kdyby/console": "~2.8",
-		"nette/bootstrap": "~3.0",
-		"latte/latte": "~2.4",
-		"tracy/tracy": "~2.4",
+		"nette/bootstrap": "~3.2.1",
+		"latte/latte": "~2.11",
+		"tracy/tracy": "~2.10",
 		"phpstan/phpstan": "^2.1",
 		"php-coveralls/php-coveralls": "^2.1",
 		"nette/tester": "^2.3.2",
 		"mockery/mockery": "~1.3.0",
 		"php-parallel-lint/php-parallel-lint": "^1.3",
 		"typo3/class-alias-loader": "^1.0",
-		"nette/caching": "^3.0"
+		"nette/caching": "^3.2.2",
 	},
 	"support": {
 		"email": "filip@prochazka.su",
@@ -52,13 +51,15 @@
 	"minimum-stability": "dev",
   	"prefer-stable": true,
 	"extra": {
-		"branch-alias": {
-			"dev-master": "1.3-dev"
-		},
 		"typo3/class-alias-loader": {
 			"class-alias-maps": [
 				"src/Kdyby/RabbitMq/DI/ClassAliasMap.php"
 			]
+		}
+	},
+	"config": {
+		"allow-plugins": {
+			"typo3/class-alias-loader": true
 		}
 	}
 }

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
 		}
 	],
 	"require": {
-		"php": "^7.4 | ^8.0",
+		"php": "^8.2",
 		"nette/di": "^3.0",
 		"nette/utils": "^3.0",
 		"php-amqplib/php-amqplib": "~3.1.0"

--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
 		"phpstan/phpstan": "^2.1",
 		"php-coveralls/php-coveralls": "^2.1",
 		"nette/tester": "^2.3.2",
-		"mockery/mockery": "~1.3.0",
+		"mockery/mockery": "~1.6.0",
 		"php-parallel-lint/php-parallel-lint": "^1.3",
 		"typo3/class-alias-loader": "^1.0",
 		"nette/caching": "^3.2.2",

--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
 		"nette/bootstrap": "~3.0",
 		"latte/latte": "~2.4",
 		"tracy/tracy": "~2.4",
-		"phpstan/phpstan": "^1.4",
+		"phpstan/phpstan": "^2.1",
 		"php-coveralls/php-coveralls": "^2.1",
 		"nette/tester": "^2.3.2",
 		"mockery/mockery": "~1.3.0",

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,6 @@
 	},
 	"require-dev": {
 		"nette/bootstrap": "~3.2.1",
-		"latte/latte": "~2.11",
 		"tracy/tracy": "~2.10",
 		"phpstan/phpstan": "^2.1",
 		"php-coveralls/php-coveralls": "^2.1",

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,6 @@
 		"php-amqplib/php-amqplib": "~3.7.2"
 	},
 	"require-dev": {
-		"kdyby/console": "~2.8",
 		"nette/bootstrap": "~3.2.1",
 		"latte/latte": "~2.11",
 		"tracy/tracy": "~2.10",
@@ -33,6 +32,7 @@
 		"php-parallel-lint/php-parallel-lint": "^1.3",
 		"typo3/class-alias-loader": "^1.0",
 		"nette/caching": "^3.2.2",
+        "symfony/console": "^6.4.4 | ^7.0"
 	},
 	"support": {
 		"email": "filip@prochazka.su",

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,4 +1,9 @@
 parameters:
+	level: 2
+	paths:
+		- src
+		- tests/KdybyTests
+
 	ignoreErrors:
 
 	excludePaths:

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,7 +1,7 @@
 parameters:
 	ignoreErrors:
 
-	excludes_analyse:
+	excludePaths:
 		- *src/Kdyby/RabbitMq/DI/ClassAliasMap.php
 
 

--- a/src/Kdyby/RabbitMq/AmqpMember.php
+++ b/src/Kdyby/RabbitMq/AmqpMember.php
@@ -22,6 +22,11 @@ abstract class AmqpMember
 	protected $conn;
 
 	/**
+	 * @var \Psr\Log\LoggerInterface
+	 */
+	protected $logger;
+
+	/**
 	 * @var \Kdyby\RabbitMq\Channel
 	 */
 	protected $ch;
@@ -89,9 +94,14 @@ abstract class AmqpMember
 	 */
 	protected $queueDeclared = FALSE;
 
-	public function __construct(Connection $conn, ?string $consumerTag = NULL)
+	public function __construct(
+		Connection $conn,
+		\Psr\Log\LoggerInterface $logger,
+		?string $consumerTag = NULL,
+	)
 	{
 		$this->conn = $conn;
+		$this->logger = $logger;
 		$this->consumerTag = empty($consumerTag) ? \sprintf('PHPPROCESS_%s_%s', \gethostname(), \getmypid()) : $consumerTag;
 
 		if (!($conn instanceof AMQPLazyConnection)) {

--- a/src/Kdyby/RabbitMq/AnonymousConsumer.php
+++ b/src/Kdyby/RabbitMq/AnonymousConsumer.php
@@ -9,7 +9,7 @@ class AnonymousConsumer extends \Kdyby\RabbitMq\Consumer
 
 	public function __construct(Connection $conn)
 	{
-		parent::__construct($conn);
+		parent::__construct($conn, new \Psr\Log\NullLogger);
 
 		$this->setQueueOptions([
 			'name' => '',

--- a/src/Kdyby/RabbitMq/Command/AnonConsumerCommand.php
+++ b/src/Kdyby/RabbitMq/Command/AnonConsumerCommand.php
@@ -8,6 +8,7 @@ use Kdyby\RabbitMq\AnonymousConsumer;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
+#[\Symfony\Component\Console\Attribute\AsCommand(name: 'rabbitmq:anon-consumer')]
 class AnonConsumerCommand extends \Kdyby\RabbitMq\Command\BaseConsumerCommand
 {
 
@@ -15,7 +16,6 @@ class AnonConsumerCommand extends \Kdyby\RabbitMq\Command\BaseConsumerCommand
 	{
 		parent::configure();
 
-		$this->setName('rabbitmq:anon-consumer');
 		$this->setDescription('Starts an anonymouse configured consumer');
 
 		$this->getDefinition()->getOption('messages')->setDefault(1);

--- a/src/Kdyby/RabbitMq/Command/ConsumerCommand.php
+++ b/src/Kdyby/RabbitMq/Command/ConsumerCommand.php
@@ -4,6 +4,7 @@ declare(strict_types = 1);
 
 namespace Kdyby\RabbitMq\Command;
 
+#[\Symfony\Component\Console\Attribute\AsCommand(name: 'rabbitmq:consumer')]
 class ConsumerCommand extends \Kdyby\RabbitMq\Command\BaseConsumerCommand
 {
 
@@ -11,7 +12,6 @@ class ConsumerCommand extends \Kdyby\RabbitMq\Command\BaseConsumerCommand
 	{
 		parent::configure();
 
-		$this->setName('rabbitmq:consumer');
 		$this->setDescription('Starts a configured consumer');
 	}
 

--- a/src/Kdyby/RabbitMq/Command/PurgeConsumerCommand.php
+++ b/src/Kdyby/RabbitMq/Command/PurgeConsumerCommand.php
@@ -9,6 +9,7 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
+#[\Symfony\Component\Console\Attribute\AsCommand(name: 'rabbitmq:purge')]
 class PurgeConsumerCommand extends \Symfony\Component\Console\Command\Command
 {
 
@@ -21,7 +22,6 @@ class PurgeConsumerCommand extends \Symfony\Component\Console\Command\Command
 	protected function configure(): void
 	{
 		$this
-			->setName('rabbitmq:purge')
 			->setDescription('Purges all messages in queue associated with given consumer')
 			->addArgument('name', InputArgument::REQUIRED, 'Consumer Name')
 			->addOption('no-confirmation', NULL, InputOption::VALUE_NONE, 'Whether it must be confirmed before purging');

--- a/src/Kdyby/RabbitMq/Command/PurgeConsumerCommand.php
+++ b/src/Kdyby/RabbitMq/Command/PurgeConsumerCommand.php
@@ -32,7 +32,13 @@ class PurgeConsumerCommand extends \Symfony\Component\Console\Command\Command
 		$noConfirmation = (bool) $input->getOption('no-confirmation');
 
 		if (!$noConfirmation && $input->isInteractive()) {
-			$confirmation = $this->getHelper('dialog')->askConfirmation($output, \sprintf('<question>Are you sure you wish to purge "%s" queue? (y/n)</question>', $input->getArgument('name')), FALSE);
+			$question = new \Symfony\Component\Console\Question\ConfirmationQuestion(
+				question: \sprintf('<question>Are you sure you wish to purge "%s" queue? (y/n)</question>', $input->getArgument('name')),
+				default: false,
+			);
+			/** @var \Symfony\Component\Console\Helper\SymfonyQuestionHelper $helper */
+			$helper = $this->getHelper('dialog');
+			$confirmation = $helper->ask($input, $output, $question);
 			if (!$confirmation) {
 				$output->writeln('<error>Purging cancelled!</error>');
 

--- a/src/Kdyby/RabbitMq/Command/RpcServerCommand.php
+++ b/src/Kdyby/RabbitMq/Command/RpcServerCommand.php
@@ -9,6 +9,7 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
+#[\Symfony\Component\Console\Attribute\AsCommand(name: 'rabbitmq:rpc-server')]
 class RpcServerCommand extends \Symfony\Component\Console\Command\Command
 {
 
@@ -21,7 +22,6 @@ class RpcServerCommand extends \Symfony\Component\Console\Command\Command
 	protected function configure(): void
 	{
 		$this
-			->setName('rabbitmq:rpc-server')
 			->setDescription('Starts a configured RPC server')
 			->addArgument('name', InputArgument::REQUIRED, 'Server Name')
 			->addOption('messages', 'm', InputOption::VALUE_OPTIONAL, 'Messages to consume', 0)

--- a/src/Kdyby/RabbitMq/Command/SetupFabricCommand.php
+++ b/src/Kdyby/RabbitMq/Command/SetupFabricCommand.php
@@ -9,6 +9,7 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
+#[\Symfony\Component\Console\Attribute\AsCommand(name: 'rabbitmq:setup-fabric')]
 class SetupFabricCommand extends \Symfony\Component\Console\Command\Command
 {
 
@@ -21,7 +22,6 @@ class SetupFabricCommand extends \Symfony\Component\Console\Command\Command
 	protected function configure(): void
 	{
 		$this
-			->setName('rabbitmq:setup-fabric')
 			->setDescription('Sets up the Rabbit MQ fabric')
 			->addOption('debug', 'd', InputOption::VALUE_NONE, 'Enable Debugging');
 	}

--- a/src/Kdyby/RabbitMq/Command/StdInProducerCommand.php
+++ b/src/Kdyby/RabbitMq/Command/StdInProducerCommand.php
@@ -9,6 +9,7 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
+#[\Symfony\Component\Console\Attribute\AsCommand(name: 'rabbitmq:stdin-producer')]
 class StdInProducerCommand extends \Symfony\Component\Console\Command\Command
 {
 
@@ -21,7 +22,6 @@ class StdInProducerCommand extends \Symfony\Component\Console\Command\Command
 	protected function configure(): void
 	{
 		$this
-			->setName('rabbitmq:stdin-producer')
 			->setDescription('Creates message from given STDIN and passes it to configured producer')
 			->addArgument('name', InputArgument::REQUIRED, 'Producer Name')
 			->addOption('debug', 'd', InputOption::VALUE_OPTIONAL, 'Enable Debugging', FALSE);

--- a/src/Kdyby/RabbitMq/Connection.php
+++ b/src/Kdyby/RabbitMq/Connection.php
@@ -119,7 +119,10 @@ class Connection extends \PhpAmqpLib\Connection\AMQPLazyConnection implements \K
 	// phpcs:disable SlevomatCodingStandard.TypeHints.TypeHintDeclaration.MissingReturnTypeHint,SlevomatCodingStandard.TypeHints.TypeHintDeclaration.MissingParameterTypeHint
 	public function channel($id = NULL): Channel
 	{
-		if (isset($this->channels[$id])) {
+		if (
+			$id !== NULL
+			&& isset($this->channels[$id])
+		) {
 			return $this->channels[$id];
 		}
 

--- a/src/Kdyby/RabbitMq/Consumer.php
+++ b/src/Kdyby/RabbitMq/Consumer.php
@@ -112,6 +112,7 @@ class Consumer extends \Kdyby\RabbitMq\BaseConsumer
 					$this->logger->debug('Consumer idle timeout reached.', ['rabbitmq_consumer' => $this->exchangeOptions['name']]);
 
 					$this->getChannel()->getConnection()?->checkHeartBeat();
+					$this->getChannel()->getConnection()?->reconnect();
 				}
 			}
 

--- a/src/Kdyby/RabbitMq/Consumer.php
+++ b/src/Kdyby/RabbitMq/Consumer.php
@@ -110,6 +110,8 @@ class Consumer extends \Kdyby\RabbitMq\BaseConsumer
 					// nothing bad happened, right?
 					// intentionally not throwing the exception
 					$this->logger->debug('Consumer idle timeout reached.', ['rabbitmq_consumer' => $this->exchangeOptions['name']]);
+
+					$this->getChannel()->getConnection()?->checkHeartBeat();
 				}
 			}
 

--- a/src/Kdyby/RabbitMq/Consumer.php
+++ b/src/Kdyby/RabbitMq/Consumer.php
@@ -82,6 +82,13 @@ class Consumer extends \Kdyby\RabbitMq\BaseConsumer
 		$this->setupConsumer();
 		$this->onStart($this);
 
+		$this->logger->debug('Consumer started', [
+			'rabbitmq_consumer' => $this->exchangeOptions['name'],
+			'queue' => $this->queueOptions['name'],
+			'target_messages' => $msgAmount,
+			'memory_limit_mb' => $this->memoryLimit,
+		]);
+
 		$previousErrorHandler = \set_error_handler(static function (int $errno, string $errstr, string $errfile, int $errline) use (&$previousErrorHandler) {
 			if (!\preg_match('~stream_select\\(\\)~i', $errstr)) {
 				$args = \func_get_args();
@@ -96,16 +103,29 @@ class Consumer extends \Kdyby\RabbitMq\BaseConsumer
 				$this->maybeStopConsumer();
 
 				try {
+					$this->logger->debug('Waiting for incoming messages...');
 					$this->getChannel()->wait(NULL, FALSE, $this->getIdleTimeout());
 				} catch (\PhpAmqpLib\Exception\AMQPTimeoutException $e) {
 					$this->onTimeout($this);
 					// nothing bad happened, right?
 					// intentionally not throwing the exception
+					$this->logger->debug('Consumer idle timeout reached.', ['rabbitmq_consumer' => $this->exchangeOptions['name']]);
 				}
 			}
 
+			$this->logger->debug('Consumer loop finished normally', [
+				'rabbitmq_consumer' => $this->exchangeOptions['name'],
+				'consumed_messages' => $this->consumed,
+			]);
+
 		} catch (\PhpAmqpLib\Exception\AMQPRuntimeException $e) {
 			\restore_error_handler();
+
+			$this->logger->debug('AMQP runtime exception', [
+				'rabbitmq_consumer' => $this->exchangeOptions['name'],
+				'exception' => $e->getMessage(),
+				'force_stop' => $this->forceStop,
+			]);
 
 			// sending kill signal to the consumer causes the stream_select to return false
 			// the reader doesn't like the false value, so it throws AMQPRuntimeException
@@ -118,10 +138,22 @@ class Consumer extends \Kdyby\RabbitMq\BaseConsumer
 		} catch (AMQPExceptionInterface $e) {
 			\restore_error_handler();
 
+			$this->logger->debug('AMQP exception', [
+				'rabbitmq_consumer' => $this->exchangeOptions['name'],
+				'exception' => $e->getMessage(),
+				'exception_class' => \get_class($e),
+			]);
+
 			$this->onError($this, $e);
 			throw $e;
 
 		} catch (\Kdyby\RabbitMq\Exception\TerminateException $e) {
+			$this->logger->debug('Consumer terminated', [
+				'rabbitmq_consumer' => $this->exchangeOptions['name'],
+				'consumed_messages' => $this->consumed,
+				'target_messages' => $this->target,
+			]);
+
 			$this->stopConsuming();
 		}
 	}
@@ -137,6 +169,13 @@ class Consumer extends \Kdyby\RabbitMq\BaseConsumer
 	public function processMessage(AMQPMessage $msg): void
 	{
 		$this->onConsume($this, $msg);
+
+		$this->logger->debug('Processing message', [
+			'rabbitmq_consumer' => $this->exchangeOptions['name'],
+			'delivery_tag' => $msg->delivery_info['delivery_tag'] ?? null,
+			'routing_key' => $msg->delivery_info['routing_key'] ?? null,
+		]);
+
 		try {
 			$processFlag = \call_user_func($this->callback, $msg);
 			$this->handleProcessMessage($msg, $processFlag);
@@ -146,6 +185,13 @@ class Consumer extends \Kdyby\RabbitMq\BaseConsumer
 			throw $e;
 
 		} catch (\Throwable $e) {
+			$this->logger->debug('Exception during message processing', [
+				'rabbitmq_consumer' => $this->exchangeOptions['name'],
+				'delivery_tag' => $msg->delivery_info['delivery_tag'] ?? null,
+				'exception' => $e->getMessage(),
+				'exception_class' => \get_class($e),
+			]);
+
 			$this->onReject($this, $msg, IConsumer::MSG_REJECT_REQUEUE);
 			throw $e;
 		}
@@ -162,10 +208,21 @@ class Consumer extends \Kdyby\RabbitMq\BaseConsumer
 			$msg->delivery_info['channel']->basic_reject($msg->delivery_info['delivery_tag'], TRUE);
 			$this->onReject($this, $msg, $processFlag);
 
+			$this->logger->debug('Message rejected and requeued', [
+				'rabbitmq_consumer' => $this->exchangeOptions['name'],
+				'delivery_tag' => $msg->delivery_info['delivery_tag'],
+				'process_flag' => $processFlag,
+			]);
+
 		} elseif ($processFlag === IConsumer::MSG_SINGLE_NACK_REQUEUE) {
 			// NACK and requeue message to RabbitMQ
 			$msg->delivery_info['channel']->basic_nack($msg->delivery_info['delivery_tag'], FALSE, TRUE);
 			$this->onReject($this, $msg, $processFlag);
+
+			$this->logger->debug('Message NACKed and requeued', [
+				'rabbitmq_consumer' => $this->exchangeOptions['name'],
+				'delivery_tag' => $msg->delivery_info['delivery_tag'],
+			]);
 
 		} else {
 			if ($processFlag === IConsumer::MSG_REJECT) {
@@ -173,10 +230,20 @@ class Consumer extends \Kdyby\RabbitMq\BaseConsumer
 				$msg->delivery_info['channel']->basic_reject($msg->delivery_info['delivery_tag'], FALSE);
 				$this->onReject($this, $msg, $processFlag);
 
+				$this->logger->debug('Message rejected and dropped', [
+					'rabbitmq_consumer' => $this->exchangeOptions['name'],
+					'delivery_tag' => $msg->delivery_info['delivery_tag'],
+				]);
+
 			} else {
 				// Remove message from queue only if callback return not false
 				$msg->delivery_info['channel']->basic_ack($msg->delivery_info['delivery_tag']);
 				$this->onAck($this, $msg);
+
+				$this->logger->debug('Message acknowledged', [
+					'rabbitmq_consumer' => $this->exchangeOptions['name'],
+					'delivery_tag' => $msg->delivery_info['delivery_tag'],
+				]);
 			}
 		}
 
@@ -184,6 +251,13 @@ class Consumer extends \Kdyby\RabbitMq\BaseConsumer
 		$this->maybeStopConsumer();
 
 		if ($this->isRamAlmostOverloaded()) {
+			$this->logger->debug('Memory limit reached, stopping consumer', [
+				'rabbitmq_consumer' => $this->exchangeOptions['name'],
+				'memory_usage_mb' => \round(\memory_get_usage(TRUE) / 1024 / 1024, 2),
+				'memory_limit_mb' => $this->memoryLimit,
+				'consumed_messages' => $this->consumed,
+			]);
+
 			$this->stopConsuming();
 		}
 	}

--- a/src/Kdyby/RabbitMq/Diagnostics/Panel.php
+++ b/src/Kdyby/RabbitMq/Diagnostics/Panel.php
@@ -102,10 +102,6 @@ class Panel implements \Tracy\IBarPanel
 
 		\ob_start();
 		// phpcs:disable SlevomatCodingStandard.Variables.UnusedVariable.UnusedVariable
-		$esc = \class_exists('Nette\Templating\Helpers')
-			? ['Nette\Templating\Helpers', 'escapeHtml']
-			: ['Latte\Runtime\Filters', 'escapeHtml'];
-		// phpcs:disable SlevomatCodingStandard.Variables.UnusedVariable.UnusedVariable
 		$click = \class_exists('\Tracy\Dumper')
 			? static function ($o, $c = FALSE) {
 				return \Tracy\Dumper::toHtml($o, ['collapse' => $c]);

--- a/src/Kdyby/RabbitMq/Diagnostics/panel.phtml
+++ b/src/Kdyby/RabbitMq/Diagnostics/panel.phtml
@@ -10,8 +10,8 @@
 </style>
 
 <h1>
-	Published messages: <?php echo $esc(count($this->messages)); ?>,
-	workers: <?php echo $esc($runningWorkers); ?>/<?php echo $esc($configuredWorkers); ?>
+	Published messages: <?php echo \Tracy\Helpers::escapeHtml(count($this->messages)); ?>,
+	workers: <?php echo \Tracy\Helpers::escapeHtml($runningWorkers); ?>/<?php echo \Tracy\Helpers::escapeHtml($configuredWorkers); ?>
 </h1>
 <div class="nette-inner tracy-inner nette-rabbitMqPanel">
 	<?php if ($runningWorkers): ?>
@@ -22,8 +22,8 @@
 			</tr>
 			<?php foreach ($workers as $serviceName => $instances): ?>
 				<tr>
-					<td><?php echo $esc($serviceName); ?></td>
-					<td><strong><?php if ($instances === FALSE) { ?>Error<?php } else { ?><?php echo $esc($instances); ?><?php } ?></strong></td>
+					<td><?php echo \Tracy\Helpers::escapeHtml($serviceName); ?></td>
+					<td><strong><?php if ($instances === FALSE) { ?>Error<?php } else { ?><?php echo \Tracy\Helpers::escapeHtml($instances); ?><?php } ?></strong></td>
 				</tr>
 			<?php endforeach; ?>
 		</table>
@@ -38,11 +38,11 @@
 			<table width="690">
 				<tr>
 					<th width="250">Exchange:</th>
-					<td><code><?php echo $esc($message['exchange']); ?></code></td>
+					<td><code><?php echo \Tracy\Helpers::escapeHtml($message['exchange']); ?></code></td>
 				</tr>
 				<?php if (!empty($message['routingKey'])): ?><tr>
 					<th>Routing&nbsp;key:</th>
-					<td><code><?php echo $esc($message['routingKey']); ?></code></td>
+					<td><code><?php echo \Tracy\Helpers::escapeHtml($message['routingKey']); ?></code></td>
 				</tr><?php endif; ?>
 				<?php $properties = $message['msg']->get_properties(); if (!empty($properties)): ?><tr>
 					<th>Properties:</th>
@@ -53,7 +53,7 @@
 					<td><?php echo $click($message['msg']->delivery_info, TRUE); ?></td>
 				</tr><?php endif; ?>
 				<tr>
-					<td colspan="2"><?php echo is_scalar($message['msg']->body) ? ('<code>' . $esc($message['msg']->body) . '</code>') : $click($message['msg']->body, TRUE); ?></td>
+					<td colspan="2"><?php echo is_scalar($message['msg']->body) ? ('<code>' . \Tracy\Helpers::escapeHtml($message['msg']->body) . '</code>') : $click($message['msg']->body, TRUE); ?></td>
 				</tr>
 			</table><br>
 		<?php endforeach; ?>

--- a/tests/KdybyTests/RabbitMq/Mock/ChannelMock.php
+++ b/tests/KdybyTests/RabbitMq/Mock/ChannelMock.php
@@ -13,24 +13,24 @@ class ChannelMock extends \Kdyby\RabbitMq\Channel
 	public $calls = [];
 
 	// phpcs:disable SlevomatCodingStandard.TypeHints.TypeHintDeclaration.MissingReturnTypeHint,SlevomatCodingStandard.TypeHints.TypeHintDeclaration.MissingParameterTypeHint,PSR1.Methods.CamelCapsMethodName
-	protected function channel_alert($args)
+	protected function channel_alert(\PhpAmqpLib\Wire\AMQPReader $reader): void
 	{
 		$this->calls[] = [__FUNCTION__] + \get_defined_vars();
-		parent::channel_alert($args);
+		parent::channel_alert($reader);
 	}
 
 	// phpcs:disable SlevomatCodingStandard.TypeHints.TypeHintDeclaration.MissingReturnTypeHint,SlevomatCodingStandard.TypeHints.TypeHintDeclaration.MissingParameterTypeHint,PSR1.Methods.CamelCapsMethodName
-	protected function channel_close($args)
+	protected function channel_close(\PhpAmqpLib\Wire\AMQPReader $reader): void
 	{
 		$this->calls[] = [__FUNCTION__] + \get_defined_vars();
-		parent::channel_close($args);
+		parent::channel_close($reader);
 	}
 
 	// phpcs:disable SlevomatCodingStandard.TypeHints.TypeHintDeclaration.MissingReturnTypeHint,SlevomatCodingStandard.TypeHints.TypeHintDeclaration.MissingParameterTypeHint,PSR1.Methods.CamelCapsMethodName
-	protected function channel_flow($args)
+	protected function channel_flow(\PhpAmqpLib\Wire\AMQPReader $reader): void
 	{
 		$this->calls[] = [__FUNCTION__] + \get_defined_vars();
-		parent::channel_flow($args);
+		parent::channel_flow($reader);
 	}
 
 	// phpcs:disable SlevomatCodingStandard.TypeHints.TypeHintDeclaration.MissingReturnTypeHint,SlevomatCodingStandard.TypeHints.TypeHintDeclaration.MissingParameterTypeHint,PSR1.Methods.CamelCapsMethodName

--- a/tests/KdybyTests/RabbitMq/files/nette-reset.neon
+++ b/tests/KdybyTests/RabbitMq/files/nette-reset.neon
@@ -7,9 +7,3 @@ extensions:
 services:
 	cacheStorage:
 		class: Nette\Caching\Storages\MemoryStorage
-
-http:
-	frames: null
-
-session:
-	autoStart: false

--- a/tests/KdybyTests/RabbitMq/files/nette-reset.neon
+++ b/tests/KdybyTests/RabbitMq/files/nette-reset.neon
@@ -2,7 +2,6 @@ php:
 	date.timezone: Europe/Prague
 
 extensions:
-	console: Kdyby\Console\DI\ConsoleExtension
 
 services:
 	cacheStorage:


### PR DESCRIPTION
This pull request updates dependencies to support newer versions of PHP and related libraries, refactors code to use modern Symfony console helpers, improves type safety in test mocks, and makes configuration changes for Composer and PHPStan. These changes help keep the codebase current, improve reliability, and ensure compatibility with the latest tooling.

**Dependency and compatibility updates:**

* Updated the minimum required PHP version to `^8.2` and bumped versions for several dependencies in `composer.json`, including `nette/utils`, `php-amqplib/php-amqplib`, `latte/latte`, `tracy/tracy`, and `phpstan/phpstan`. Added `symfony/console` as a new dev dependency.
* Updated the Composer config to add plugin allowances and removed the `branch-alias` setting.

**Code modernization and refactoring:**

* Refactored the confirmation prompt in `PurgeConsumerCommand.php` to use Symfony's `ConfirmationQuestion` instead of the deprecated dialog helper, improving code clarity and future compatibility.
* Improved type safety in `ChannelMock.php` by adding explicit type hints to method parameters and return types, and updated parent method calls accordingly.

**Configuration and tooling:**

* Updated PHPStan configuration by replacing `excludes_analyse` with `excludePaths` for better compatibility with newer PHPStan versions.
* Cleaned up the test configuration in `nette-reset.neon` by removing unused or deprecated service definitions.